### PR TITLE
Build wheels for Python 3.10 and bump the OS to 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ jobs:
   build:
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9"]
-    runs-on: ubuntu-18.04
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install python ${{ matrix.python }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As we have increasing number of OMERO deployments on Python 3.10, I am looking into updating the `omero-py/omero-web` to have at least some minimal coverage of these environments.

In order to add these environments to the Tox workflows, this builds pre-compiled wheels for the whole spectrum of 3.6 -> 3.10 versions.
The operating system is also updated to Ubuntu 20.04 as Ubuntu 18.04 is reaching active support end-of-life in April 2023 (https://endoflife.date/ubuntu).


See https://github.com/sbesson/omero-web/actions/runs/3600276251 and https://github.com/sbesson/omero-py/actions/runs/3600314304 for downstream examples consuming these wheels 

Proposed tag: `0.2.0`